### PR TITLE
fix: handle multiple game invites correctly

### DIFF
--- a/client/src/components/Toasts/GameInviteToast/GameInviteToast.tsx
+++ b/client/src/components/Toasts/GameInviteToast/GameInviteToast.tsx
@@ -19,7 +19,7 @@ export const GameInviteToast = ({ nickname, navigate, toast, socketGame }: Props
   }
 
   function handleAcceptInvite() {
-    if (window.location.pathname === '/home/pong/game') return;
+    if (window.location.pathname.includes('home/pong')) return;
     socketGame.emit("acceptInvite", nickname);
 
     setTimeout(() => {

--- a/server/src/gateway/service/room.service.ts
+++ b/server/src/gateway/service/room.service.ts
@@ -343,9 +343,7 @@ export class RoomService {
 
     // remove invite
     this.inviteUsers = this.inviteUsers.filter(
-      (invite) =>
-        invite.to !== this.getNicknameFromClient(client) ||
-        invite.from !== userNickname,
+      (invite) => invite.from !== userNickname,
     );
   }
 


### PR DESCRIPTION
Trata casos em que o usuário possui multiplos convites:

- ao receber múltiplos convites, não permite aceitá-los na tela do game
- ao ter um convite aceito, apaga todos os outros invites